### PR TITLE
Use String instead of URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /*.ipr
 /*.iml
 /.vscode/
-
+/out/

--- a/src/main/java/no/fint/betaling/model/Claim.java
+++ b/src/main/java/no/fint/betaling/model/Claim.java
@@ -2,7 +2,6 @@ package no.fint.betaling.model;
 
 import lombok.Data;
 
-import java.net.URI;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -24,7 +23,7 @@ public class Claim {
     private User createdBy;
     private Organisation organisationUnit;
     private Principal principal;
-    private URI invoiceUri;
+    private String invoiceUri;
     private List<OrderItem> orderItems;
     private ClaimStatus claimStatus;
     private String statusMessage;

--- a/src/main/java/no/fint/betaling/model/Customer.java
+++ b/src/main/java/no/fint/betaling/model/Customer.java
@@ -2,8 +2,6 @@ package no.fint.betaling.model;
 
 import lombok.Data;
 
-import java.net.URI;
-
 @Data
 public class Customer {
     private String id;
@@ -13,5 +11,5 @@ public class Customer {
     private String postalAddress;
     private String postalCode;
     private String city;
-    private URI person;
+    private String person;
 }

--- a/src/main/java/no/fint/betaling/model/Lineitem.java
+++ b/src/main/java/no/fint/betaling/model/Lineitem.java
@@ -2,13 +2,11 @@ package no.fint.betaling.model;
 
 import lombok.Data;
 
-import java.net.URI;
-
 @Data
 public class Lineitem {
     private String itemCode;
     private Long itemPrice;
     private Long taxrate;
     private String description;
-    private URI uri;
+    private String uri;
 }

--- a/src/main/java/no/fint/betaling/model/Principal.java
+++ b/src/main/java/no/fint/betaling/model/Principal.java
@@ -2,7 +2,6 @@ package no.fint.betaling.model;
 
 import lombok.Data;
 
-import java.net.URI;
 import java.util.Set;
 
 @Data
@@ -10,5 +9,5 @@ public class Principal {
     private String code;
     private String description;
     private Set<String> lineitems;
-    private URI uri;
+    private String uri;
 }

--- a/src/main/java/no/fint/betaling/model/Taxcode.java
+++ b/src/main/java/no/fint/betaling/model/Taxcode.java
@@ -2,12 +2,10 @@ package no.fint.betaling.model;
 
 import lombok.Data;
 
-import java.net.URI;
-
 @Data
 public class Taxcode {
     private String code;
     private Long rate;
     private String description;
-    private URI uri;
+    private String uri;
 }


### PR DESCRIPTION
The BSON encoding of URI is ugly:

```
"uri" : { "scheme" : "https", "authority" : "beta1.felleskomponent.no", "host" : "beta1.felleskomponent.no", "port" : -1, "path" : "/betaling/varelinje/systemid/1234566", "schemeSpecificPart" : "//beta1.felleskomponent.no/betaling/varelinje/systemid/1234566", "hash" : 0, "string" : "https://beta1.felleskomponent.no/betaling/varelinje/systemid/1234566" } 
```